### PR TITLE
fix a spelling mistake in working_with_javascript_in_rails.md

### DIFF
--- a/source/zh-TW/working_with_javascript_in_rails.md
+++ b/source/zh-TW/working_with_javascript_in_rails.md
@@ -285,7 +285,7 @@ class UsersController < ApplicationController
   end
 ```
 
-注意 `respond_to` 區塊內的 `format.js`，這是 Cotroller 回應 Ajax 請求的地方。`create` 動作對應 `app/views/users/create.js.erb`：
+注意 `respond_to` 區塊內的 `format.js`，這是 Controller 回應 Ajax 請求的地方。`create` 動作對應 `app/views/users/create.js.erb`：
 
 ```erb
 $("<%= escape_javascript(render @user) %>").appendTo("#users");


### PR DESCRIPTION
文字修改：
修改位置：“ 在 Rails 使用 JavaScript  ” 。在文中 Chapter 4.1 相关位置改为 Controller